### PR TITLE
Patches required to support new HBM DRAMSim2 SST component

### DIFF
--- a/DRAMSim.h
+++ b/DRAMSim.h
@@ -37,16 +37,16 @@
 
 using std::string;
 
-namespace DRAMSim 
+namespace DRAMSim
 {
-  class MultiChannelMemorySystem 
+  class MultiChannelMemorySystem
   {
-    public: 
+    public:
       bool addTransaction(bool isWrite, uint64_t addr);
       void update();
       void printStats(bool finalStats);
-      bool willAcceptTransaction(); 
-      bool willAcceptTransaction(uint64_t addr); 
+      bool willAcceptTransaction();
+      bool willAcceptTransaction(uint64_t addr);
 
       void RegisterCallbacks(TransactionCompleteCB *readDone, TransactionCompleteCB *writeDone);
   };

--- a/DRAMSim.h
+++ b/DRAMSim.h
@@ -34,6 +34,7 @@
 
 #include "Callback.h"
 #include <string>
+#include "Stats.h"
 
 using std::string;
 
@@ -48,7 +49,16 @@ namespace DRAMSim
       bool willAcceptTransaction();
       bool willAcceptTransaction(uint64_t addr);
 
-      void RegisterCallbacks(TransactionCompleteCB *readDone, TransactionCompleteCB *writeDone);
+      void RegisterCallbacks(TransactionCompleteCB *readDone,
+                             TransactionCompleteCB *writeDone,
+                             void (*reportPower)(double bgpower,
+                                                 double burstpower,
+                                                 double refreshpower,
+                                                 double actprepower));
+
+      // SST Statistics
+      bool getStats( double *stat, DSIM_STAT metric );
+      bool getStats( uint64_t *stat, DSIM_STAT metric );
   };
 
   MultiChannelMemorySystem *getMemorySystemInstance(const string &dev, const string &sys, 

--- a/HBMDRAMSim.h
+++ b/HBMDRAMSim.h
@@ -1,0 +1,42 @@
+/*********************************************************************************
+*  Copyright (c) 2010-2011, Elliott Cooper-Balis
+*                             Paul Rosenfeld
+*                             Bruce Jacob
+*                             University of Maryland
+*                             dramninjas [at] gmail [dot] com
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions are met:
+*
+*     * Redistributions of source code must retain the above copyright notice,
+*        this list of conditions and the following disclaimer.
+*
+*     * Redistributions in binary form must reproduce the above copyright notice,
+*        this list of conditions and the following disclaimer in the documentation
+*        and/or other materials provided with the distribution.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+*  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+*  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+*  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+*  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************************/
+
+/*
+ * HBMDRAMSIM.H is utilized to bridge the SST-Elements:HBMDRAMSim to DRAMSim
+ * with the HBM additions
+ *
+ */
+
+#ifndef HBMDRAMSIM_H
+#define HBMDRAMSIM_H
+
+#include "DRAMSim.h"
+
+#endif // HBMDRAMSIM_H

--- a/MemoryController.h
+++ b/MemoryController.h
@@ -42,19 +42,9 @@
 #include "BusPacket.h"
 #include "BankState.h"
 #include "Rank.h"
+#include "Stats.h"
 
 using namespace std;
-
-// stats enumerated types
-typedef enum{
-  TOTAL_TRANSACTIONS,
-  TOTAL_BYTES_TRANSFERRED,
-  TOTAL_BANDWIDTH,
-  TOTAL_READS,
-  TOTAL_WRITES,
-  PENDING_READ_TRANSACTIONS,
-  PENDING_RTN_TRANSACTIONS
-}DSIM_STAT;
 
 namespace DRAMSim
 {

--- a/MemoryController.h
+++ b/MemoryController.h
@@ -45,6 +45,17 @@
 
 using namespace std;
 
+// stats enumerated types
+typedef enum{
+  TOTAL_TRANSACTIONS,
+  TOTAL_BYTES_TRANSFERRED,
+  TOTAL_BANDWIDTH,
+  TOTAL_READS,
+  TOTAL_WRITES,
+  PENDING_READ_TRANSACTIONS,
+  PENDING_RTN_TRANSACTIONS
+}DSIM_STAT;
+
 namespace DRAMSim
 {
 #ifdef DEBUG_LATENCY
@@ -92,7 +103,11 @@ public:
   void updateBankStates();
   void update();
   void printStats(bool finalStats = false);
-  void resetStats(); 
+  void resetStats();
+
+  // retrieve the target stats entry 'metric' in 'stat'
+  bool getStats( double *stat, DSIM_STAT metric );
+  bool getStats( uint64_t *stat, DSIM_STAT metric );
 
 public:
   vector<Transaction*> transactionQueue;

--- a/MemorySystem.cpp
+++ b/MemorySystem.cpp
@@ -117,6 +117,14 @@ bool MemorySystem::addTransaction(bool isWrite, uint64_t addr)
   }
 }
 
+bool MemorySystem::getStats( double *stat, DSIM_STAT metric ){
+  return memoryController->getStats(stat, metric);
+}
+
+bool MemorySystem::getStats( uint64_t *stat, DSIM_STAT metric ){
+  return memoryController->getStats(stat, metric);
+}
+
 void MemorySystem::printStats(bool finalStats)
 {
   memoryController->printStats(finalStats);

--- a/MemorySystem.h
+++ b/MemorySystem.h
@@ -53,6 +53,9 @@ class MemorySystem : public SimulatorObject
     bool WillAcceptTransaction();
     void RegisterCallbacks(Callback_t *readDone, Callback_t *writeDone);
 
+    bool getStats( double *stat, DSIM_STAT metric );
+    bool getStats( uint64_t *stat, DSIM_STAT metric );
+
   public:
     Callback_t* ReturnReadData;
     Callback_t* WriteDataDone;

--- a/MemorySystem.h
+++ b/MemorySystem.h
@@ -38,6 +38,7 @@
 #include "Transaction.h"
 #include "Callback.h"
 #include <deque>
+#include "Stats.h"
 
 namespace DRAMSim
 {

--- a/MultiChannelMemorySystem.cpp
+++ b/MultiChannelMemorySystem.cpp
@@ -122,6 +122,34 @@ bool MultiChannelMemorySystem::willAcceptTransaction(uint64_t addr)
   return channels[chan]->WillAcceptTransaction();
 }
 
+bool MultiChannelMemorySystem::getStats( double *stat, DSIM_STAT metric ){
+  double value = 0.;
+  double total = 0.;
+  for (unsigned i = 0; i < NUM_CHANS; ++i){
+    if( channels[i]->getStats( &value, metric ) ){
+      total += value;
+      value = 0.;
+    }else{
+      return false;
+    }
+  }
+  return true;
+}
+
+bool MultiChannelMemorySystem::getStats( uint64_t *stat, DSIM_STAT metric ){
+  uint64_t value = 0.;
+  uint64_t total = 0.;
+  for (unsigned i = 0; i < NUM_CHANS; ++i){
+    if( channels[i]->getStats( &value, metric ) ){
+      total += value;
+      value = 0.;
+    }else{
+      return false;
+    }
+  }
+  return true;
+}
+
 void MultiChannelMemorySystem::printStats(bool finalStats) 
 {
   for (unsigned i = 0; i < NUM_CHANS; ++i) {

--- a/MultiChannelMemorySystem.cpp
+++ b/MultiChannelMemorySystem.cpp
@@ -160,7 +160,11 @@ void MultiChannelMemorySystem::printStats(bool finalStats)
 }
 
 void MultiChannelMemorySystem::RegisterCallbacks(TransactionCompleteCB *readDone, 
-    TransactionCompleteCB *writeDone)
+    TransactionCompleteCB *writeDone,
+    void (*reportPower)(double bgpower,
+                        double burstpower,
+                        double refreshpower,
+                        double actprepower))
 {
   for (auto x: channels) 
     x->RegisterCallbacks(readDone, writeDone);

--- a/MultiChannelMemorySystem.h
+++ b/MultiChannelMemorySystem.h
@@ -47,6 +47,9 @@ class MultiChannelMemorySystem : public SimulatorObject
     void printStats(bool finalStats=false);
     void RegisterCallbacks(TransactionCompleteCB *readDone, TransactionCompleteCB *writeDone);
 
+    bool getStats( double *stat, DSIM_STAT metric );
+    bool getStats( uint64_t *stat, DSIM_STAT metric );
+
   private:
     unsigned findChannelNumber(uint64_t addr);
 

--- a/Stats.h
+++ b/Stats.h
@@ -2,19 +2,20 @@
 *  Copyright (c) 2010-2011, Elliott Cooper-Balis
 *                             Paul Rosenfeld
 *                             Bruce Jacob
-*                             University of Maryland dramninjas [at] gmail [dot] com
+*                             University of Maryland
+*                             dramninjas [at] gmail [dot] com
 *  All rights reserved.
-*  
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions are met:
-*  
+*
 *     * Redistributions of source code must retain the above copyright notice,
 *        this list of conditions and the following disclaimer.
-*  
+*
 *     * Redistributions in binary form must reproduce the above copyright notice,
 *        this list of conditions and the following disclaimer in the documentation
 *        and/or other materials provided with the distribution.
-*  
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -26,49 +27,18 @@
 *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************************/
-#include <atomic>
 
-#include "SimulatorObject.h"
-#include "Transaction.h"
-#include "SystemConfiguration.h"
-#include "MemorySystem.h"
-#include "IniReader.h"
-#include "Stats.h"
+#ifndef STATS_H
+#define STATS_H
 
-namespace DRAMSim { 
-class MultiChannelMemorySystem : public SimulatorObject 
-{
-  public: 
-    MultiChannelMemorySystem(const string &dev, const string &sys, const string &pwd, unsigned 
-        megsOfMemory);
-    virtual ~MultiChannelMemorySystem();
-    bool addTransaction(bool isWrite, uint64_t addr);
-    bool willAcceptTransaction(uint64_t addr); 
-    void update();
-    void printStats(bool finalStats=false);
-    void RegisterCallbacks(TransactionCompleteCB *readDone,
-                           TransactionCompleteCB *writeDone,
-                           void (*reportPower)(double bgpower,
-                                               double burstpower,
-                                               double refreshpower,
-                                               double actprepower));
+typedef enum{
+  TOTAL_TRANSACTIONS,
+  TOTAL_BYTES_TRANSFERRED,
+  TOTAL_BANDWIDTH,
+  TOTAL_READS,
+  TOTAL_WRITES,
+  PENDING_READ_TRANSACTIONS,
+  PENDING_RTN_TRANSACTIONS
+}DSIM_STAT;
 
-    // SST Statistics
-    bool getStats( double *stat, DSIM_STAT metric );
-    bool getStats( uint64_t *stat, DSIM_STAT metric );
-
-  private:
-    unsigned findChannelNumber(uint64_t addr);
-
-  private:
-    vector<MemorySystem*> channels; 
-    unsigned stackID;
-    string deviceIniFilename;
-    string systemIniFilename;
-    string pwd;
-    unsigned megsOfMemory; 
-
-  private:
-    static std::atomic<int> stackCount;
-}; //class MultiChannelMemorySystem
-} //namespace DRAMSim
+#endif // STATS_H


### PR DESCRIPTION
Adds basic tracing capabilities as well as small modifications to top-level class interfaces in order to support latest DRAMSim2 interfaces for SST-Elements component.  SST-Elements component patches are forthcoming.